### PR TITLE
Added an option to set the primaryKey of the eloquent model

### DIFF
--- a/config/sphinxsearch.php
+++ b/config/sphinxsearch.php
@@ -6,17 +6,20 @@ return [
     'indexes' => [
         'index_1_i' => [
             'modelname' => 'App\Model1',
-            'table' => 'table1', 
+            'table' => 'table1',
+            'primaryKey' => 'id',
             'column' => 'id'
         ],
         'index_2_i' => [
             'modelname' => 'App\Model2',
             'table' => 'table2',
+            'primaryKey' => 'id',
             'column' => 'id'
         ],
         'index_3_i' => [
             'modelname' =>  'App\Model3',
             'table' => 'table3',
+            'primaryKey' => 'id',
             'column' => 'id'
         ],
     ],


### PR DESCRIPTION
I've added a primaryKey option to the config array, and changed the corresponding lines in the `get` method so we can configure different eloquent ID than just `id`.

It automatically defaults to being `id` if  `primaryKey` is not set in the config file.

(Also, the file has been parsed to correspond to PSR-4 automatically here!)